### PR TITLE
Wrong address in "setup_privnet" function

### DIFF
--- a/neorpc/Settings.py
+++ b/neorpc/Settings.py
@@ -45,7 +45,7 @@ class SettingsHolder:
         """ Load settings from the privnet JSON config file """
         self.setup(
             [
-                "127.0.0.1:20332"
+                "http://127.0.0.1:30333"
             ]
         )
 


### PR DESCRIPTION
In "Settings.py" file, the setup_privnet function should connect to address
**http://127.0.0.1:30333**
instead of
**127.0.0.1:20332**