### PR TITLE
Update Client.py

### DIFF
--- a/neorpc/Client.py
+++ b/neorpc/Client.py
@@ -370,7 +370,7 @@ class RPCEndpoint():
 
     def setup(self):
 
-        response = requests.post(self.addr, json={'jsonrpc': '2.0', 'method': GET_BLOCK_COUNT, 'params': [], 'id': 1})
+        response = requests.post(self.addr, json={'jsonrpc': '2.0', 'method': GET_BLOCK_COUNT, 'params': [], 'id': 1}, timeout=TIMEOUT)
         self.update_endpoint_details(response)
 
         if response.status_code == 200:


### PR DESCRIPTION
Added timeout to setup RPC call using standard TIMEOUT.
Unless there was a design decision to omit it, all post requests should have a timeout as best practice.
In this case, the GET_BLOCK_COUNT RPC method should be as fast if not faster than all other calls so if it can't beat TIMEOUT variable then the others have no chance.