### PR TITLE
Fix tests by updating seeds, resolve deprecation warning

### DIFF
--- a/neorpc/Settings.py
+++ b/neorpc/Settings.py
@@ -22,22 +22,22 @@ class SettingsHolder:
         """ Load settings from the mainnet JSON config file """
         self.setup(
             [
-                "http://seed1.cityofzion.io:8080",
-                "http://seed2.cityofzion.io:8080",
-                "http://seed3.cityofzion.io:8080",
-                "http://seed4.cityofzion.io:8080",
-                "http://seed5.cityofzion.io:8080"
+                "https://seed1.cityofzion.io:443",
+                "https://seed2.cityofzion.io:443",
+                "https://seed3.cityofzion.io:443",
+                "https://seed4.cityofzion.io:443",
+                "https://seed5.cityofzion.io:443"
             ]
         )
 
     def setup_testnet(self):
         self.setup(
             [
-                "http://test1.cityofzion.io:8880",
-                "http://test2.cityofzion.io:8880",
-                "http://test3.cityofzion.io:8880",
-                "http://test4.cityofzion.io:8880",
-                "http://test5.cityofzion.io:8880"
+                "https://test1.cityofzion.io:443",
+                "https://test2.cityofzion.io:443",
+                "https://test3.cityofzion.io:443",
+                "https://test4.cityofzion.io:443",
+                "https://test5.cityofzion.io:443"
             ]
         )
 

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ try:  # pip version >= 10.0
     from pip._internal.req import parse_requirements
     from pip._internal.download import PipSession
 except ImportError:  # pip version < 10.0
-from pip.req import parse_requirements
-from pip.download import PipSession
+    from pip.req import parse_requirements
+    from pip.download import PipSession
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,10 @@
 """The setup script."""
 
 from setuptools import setup, find_packages
+try:  # pip version >= 10.0
+    from pip._internal.req import parse_requirements
+    from pip._internal.download import PipSession
+except ImportError:  # pip version < 10.0
 from pip.req import parse_requirements
 from pip.download import PipSession
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -69,7 +69,7 @@ class RPCClientTestCase(TestCase):
     def test_call_endpoint_status_moved(self):#, mocked_post):
         client = RPCClient()
 
-        responses.add(responses.POST, 'http://test5.cityofzion.io:8880/',
+        responses.add(responses.POST, 'https://test5.cityofzion.io:443/',
                       json={'Found': 'Moved'}, status=302)
 
         response = client.get_height()
@@ -357,7 +357,7 @@ class RPCEndPointTestCase(TestCase):
         self.ep2.height = 1
 
     def test_eq(self):
-        self.assertEquals(self.ep1, self.ep2)
+        self.assertEqual(self.ep1, self.ep2)
 
     def test_gt_and_ge(self):
         self.ep2.height = 2


### PR DESCRIPTION
see title, tests were failing because they connect to coz seeds which changed to https on different ports