### PR TITLE
fix raw tx_test

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -309,7 +309,9 @@ class RPCClientTestCase(TestCase):
         # so we are testing if we get back a false
         result = client.send_raw_tx(raw_tx)
 
-        self.assertEqual(result, False)
+        self.assertIn('error', result)
+        self.assertIn('Block or transaction already exists', result['error']['message'])
+
 
     def test_validate_addr(self):
 


### PR DESCRIPTION
A failed TX now does not just return `False` but has some more info in an `error` object. 

Merge this before #17 to fix the build failure there